### PR TITLE
Resolve issue with in_array() parameter getting the wrong type

### DIFF
--- a/acf-cf7-v5.php
+++ b/acf-cf7-v5.php
@@ -194,7 +194,7 @@ class acf_field_cf7 extends acf_field {
 		          	if($key == $field['value']){
 		            	$selected = 'selected="selected"';
 		          	}
-		          	if(in_array(($k+1), $field['disable'])){
+		          	if ( is_array($field['disable']) && in_array(($k+1), $field['disable']) ) {
 		            	$selected = 'disabled="disabled"';
 		          	}
 		      	}


### PR DESCRIPTION
PHP Warning: in_array() expects parameter 2 to be array. Issue https://github.com/taylormsj/acf-cf7/issues/4